### PR TITLE
FIX: setup.py after "README" was renamed to "README.rst"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+downloads/
+eggs/
+.eggs/
+*.egg-info/
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.coverage.*
+.cache
+.hypothesis/
+.pytest_cache/
+
+# Sphinx documentation
+docs/_build/
+
+# Environments
+.venv*/
+
+# Personal stuff
+__*/
+__*.txt
+__*.rst

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,16 @@
 
 from setuptools import setup, find_packages
 
-with open('README') as stream:
+with open('README.rst') as stream:
     long_desc = stream.read()
 
 requires = ['Sphinx>=1.0b2']
 
 setup(
     name='sphinxcontrib-ansi',
-    version='0.6',
-    url='http://bitbucket.org/birkenfeld/sphinx-contrib',
-    download_url='http://pypi.python.org/pypi/ansi',
+    version='0.6.1',
+    url='https://github.com/sphinx-contrib/ansi',
+    download_url='http://pypi.org/project/sphinxcontrib-ansi',
     license='BSD',
     author='Sebastian Wiesner',
     author_email='lunaryorn@googlemail.com',


### PR DESCRIPTION
Fixes the "old" problem that sphinxcontrib-ansi in v0.6 could no longer be installed  from PyPI.

In addition:

* BUMP-VERSION: 0.6.1 (was: 0.6)
* MODIFY: "url", "download_url" to Github repo, etc. (according to new location(s))