### PR TITLE
FIX: sphinx >= 2.0 problems and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+downloads/
+eggs/
+.eggs/
+*.egg-info/
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.coverage.*
+.cache
+.hypothesis/
+.pytest_cache/
+
+# Sphinx documentation
+docs/_build/
+
+# Environments
+.venv*/
+
+# Personal stuff
+__*/
+__*.txt
+__*.rst

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ MANIFEST
 .cache
 .hypothesis/
 .pytest_cache/
+py*-tests.xml
+
 
 # Sphinx documentation
 docs/_build/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+0.7.0 (UNRELEASED)
+=====================
+
+- docs: Changed URLs to github repository.
+- Add support for sphinx >= 2.0
+- Add support for newer python3 versions.
+- test: Fixed tests.
+
+RELATED:
+
+- OFFICIAL NEW REPO: https://github.com/sphinx-contrib/ansi
+- https://pypi.org/project/sphinxcontrib-ansi/0.6.dev20201023/
+  (tag missing; NOT REFLECTED on branch=master)
+
 0.6 (Jul 8, 2011)
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 sphinxcontrib-ansi
 ####################
 
-http://packages.python.org/sphinxcontrib-ansi
+https://packages.python.org/sphinxcontrib-ansi
 
 A Sphinx_ extension, which turns ANSI color sequences in Sphinx documents
 into colored HTML output.
@@ -15,11 +15,11 @@ This extension can be installed from the Python Package Index::
 
    pip install sphinxcontrib-ansi
 
-Alternatively, you can clone the sphinx-contrib_ repository from BitBucket,
+Alternatively, you can clone the `sphinx-contrib/ansi`_ repository,
 and install the extension directly from the repository::
 
-   hg clone http://bitbucket.org/birkenfeld/sphinx-contrib
-   cd sphinx-contrib/ansi
+   git clone https://github.com/sphinx-contrib/ansi sphinxcontrib-ansi
+   cd sphinxcontrib-ansi
    python setup.py install
 
 
@@ -29,6 +29,6 @@ Usage
 Please refer to the documentation_ for further information.
 
 
-.. _`Sphinx`: http://sphinx.pocoo.org/latest
-.. _`sphinx-contrib`: http://bitbucket.org/birkenfeld/sphinx-contrib
-.. _documentation: http://packages.python.org/sphinxcontrib-ansi
+.. _`Sphinx`: https://sphinx-doc.org/latest
+.. _`sphinx-contrib/ansi`: https://github.com/sphinx-contrib/ansi
+.. _documentation: https://packages.python.org/sphinxcontrib-ansi

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,29 +26,39 @@
 
 needs_sphinx = '1.0'
 
-extensions = ['sphinx.ext.intersphinx', 'sphinxcontrib.issuetracker']
+extensions = [
+    'sphinx.ext.intersphinx',
+    # DISABLED: 'sphinxcontrib.issuetracker',
+]
 
 source_suffix = '.rst'
 master_doc = 'index'
 
 project = u'sphinxcontrib-ansi'
-copyright = u'2010, 2011 Sebastian Wiesner'
-version = '0.6'
-release = '0.6'
+copyright = u'2010, 2011 Sebastian Wiesner; 2020 Jens Engel (since 0.6.1)'
+version = '0.7.0'
+release = '0.7.0'
 
-exclude_patterns = ['_build/*']
+exclude_patterns = ['build/*', '_build/*']
 
 html_theme = 'default'
 html_static_path = []
 
-intersphinx_mapping = {'python': ('http://docs.python.org/', None),
-                       'sphinx': ('http://sphinx.pocoo.org/', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+    # DISABLED: 'sphinx': ('https://sphinx-doc.org/', 'sphinx-inv.txt'),
+}
 
-issuetracker = 'bitbucket'
-issuetracker_user = 'birkenfeld'
+issuetracker = 'github'
 issuetracker_project = 'sphinx-contrib'
+issuetracker_user = 'birkenfeld'
 
 
 def setup(app):
-    app.add_description_unit('confval', 'confval',
-                             'pair: %s; configuration value')
+    if hasattr(app, 'add_object_type'):
+        app.add_object_type('confval', 'confval',
+                            'pair: %s; configuration value')
+    else:
+        # -- SUPPORTS: sphinx < 2.0
+        app.add_description_unit('confval', 'confval',
+                                 'pair: %s; configuration value')

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,8 +12,8 @@ HTML output.  Use this extension to correctly include the output of command
 line tools, which use these control sequences to color their output (like
 ``sphinx-build``, for instance).
 
-The extension is available under the terms of the BSD license, see LICENSE_
-for more information.
+The extension is available under the terms of the BSD license, 
+see LICENSE for more information.
 
 
 Installation
@@ -23,11 +23,11 @@ This extension can be installed from the Python Package Index::
 
    pip install sphinxcontrib-ansi
 
-Alternatively, you can clone the sphinx-contrib_ repository from BitBucket,
+Alternatively, you can clone the `sphinx-contrib/ansi`_ repository,
 and install the extension directly from the repository::
 
-   hg clone https://bitbucket.org/birkenfeld/sphinx-contrib
-   cd sphinx-contrib/ansi
+   git clone https://github.com/sphinx-contrib/ansi sphinxcontrib-ansi
+   cd sphinxcontrib-ansi
    python setup.py install
 
 
@@ -88,14 +88,19 @@ it known to sphinx by including the following code snippet in your
 .. code-block:: python
 
    def setup(app):
-       app.add_stylesheet('my_ansi_theme.css')
+       # -- NOTE: RemovedInSphinx40Warning:
+       # The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
+       app.add_css_file('my_ansi_theme.css')
+
+       # OLDER-SOLUTION: sphinx <= 2.0
+       # app.add_stylesheet('my_ansi_theme.css')
 
 
 Contribution
 ------------
 
 Please contact the author or create an issue in the `issue tracker`_ of the
-sphinx-contrib_ repository, if you have found any bugs or miss some
+`sphinx-contrib/ansi`_ repository, if you have found any bugs or miss some
 functionality (e.g. support for more attributes).  Patches are welcome!
 
 
@@ -106,8 +111,13 @@ functionality (e.g. support for more attributes).  Patches are welcome!
    changes.rst
 
 
-.. _`Sphinx`: http://sphinx.pocoo.org/
-.. _`sphinx-contrib`: https://bitbucket.org/birkenfeld/sphinx-contrib
-.. _`issue tracker`: https://bitbucket.org/birkenfeld/sphinx-contrib/issues
-.. _`black-on-white.css`: https://bitbucket.org/birkenfeld/sphinx-contrib/src/tip/ansi/sphinxcontrib/black-on-white.css
-.. _LICENSE: https://bitbucket.org/birkenfeld/sphinx-contrib/src/tip/LICENSE
+.. _`Sphinx`: https://www.sphinx-doc.org/
+.. _`sphinx-contrib/ansi`: https://github.com/sphinx-contrib/ansi
+.. _`issue tracker`:       https://github.com/sphinx-contrib/ansi/issues
+.. _`black-on-white.css`:  https://github.com/sphinx-contrib/ansi/blob/master/sphinxcontrib/black-on-white.css
+
+.. hidden:
+
+   BROKEN: Missing on Github.
+   .. _LICENSE: https://bitbucket.org/birkenfeld/sphinx-contrib/src/tip/LICENSE
+

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.0
 lxml
-sphinxcontrib-issuetracker>=0.7
+# DISABLED: sphinxcontrib-issuetracker>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,12 @@
 sphinx>=1.0
+-r doc/requirements.txt
+
+# -- TESTING:
 pytest>=2.0.2
 mock>=0.7
+
+# -- PYTHON2 BACKPORTS:
+pathlib;  python_version <= '3.4'
+
+# -- MORE:
+# tox

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,11 @@ from setuptools import setup, find_packages
 with open('README.rst') as stream:
     long_desc = stream.read()
 
-requires = ['Sphinx>=1.0b2']
+requires = ['sphinx>=1.0']
 
 setup(
     name='sphinxcontrib-ansi',
-    version='0.6.1',
+    version='0.7.0',
     url='https://github.com/sphinx-contrib/ansi',
     download_url='http://pypi.org/project/sphinxcontrib-ansi',
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,16 @@
 
 from setuptools import setup, find_packages
 
-with open('README') as stream:
+with open('README.rst') as stream:
     long_desc = stream.read()
 
 requires = ['Sphinx>=1.0b2']
 
 setup(
     name='sphinxcontrib-ansi',
-    version='0.6',
-    url='http://bitbucket.org/birkenfeld/sphinx-contrib',
-    download_url='http://pypi.python.org/pypi/ansi',
+    version='0.6.1',
+    url='https://github.com/sphinx-contrib/ansi',
+    download_url='http://pypi.org/project/sphinxcontrib-ansi',
     license='BSD',
     author='Sebastian Wiesner',
     author_email='lunaryorn@googlemail.com',

--- a/sphinxcontrib/ansi.py
+++ b/sphinxcontrib/ansi.py
@@ -33,7 +33,7 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@googlemail.com>
 """
 
-
+from __future__ import absolute_import, print_function
 import re
 from os import path
 
@@ -41,7 +41,10 @@ from docutils import nodes
 from docutils.parsers import rst
 from docutils.parsers.rst.directives import flag
 from sphinx.util.osutil import copyfile
-from sphinx.util.console import bold
+# DISABLED: from sphinx.util.console import bold
+
+
+__version__ = '0.7.0'
 
 
 class ansi_literal_block(nodes.literal_block):
@@ -169,19 +172,30 @@ class ANSIColorParser(object):
 
 def add_stylesheet(app):
     if app.config.html_ansi_stylesheet:
-        app.add_stylesheet('ansi.css')
+        # -- RemovedInSphinx40Warning:
+        # The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
+        if hasattr(app, 'add_css_file'):
+            app.add_css_file('ansi.css')
+        else:
+            # -- SUPPORTS: sphinx < 2.0 ?
+            app.add_stylesheet('ansi.css')
 
 
 def copy_stylesheet(app, exception):
     if app.builder.name != 'html' or exception:
         return
+
+    verbose = hasattr(app, 'info')
     stylesheet = app.config.html_ansi_stylesheet
     if stylesheet:
-        app.info(bold('Copying ansi stylesheet... '), nonl=True)
+        if verbose:
+            # DISABLED; app.info(bold('Copying ansi stylesheet... '), nonl=True)
+            app.info('Copying ansi stylesheet... ', nonl=True)
         dest = path.join(app.builder.outdir, '_static', 'ansi.css')
         source = path.abspath(path.dirname(__file__))
         copyfile(path.join(source, stylesheet), dest)
-        app.info('done')
+        if verbose:
+            app.info('done')
 
 
 class ANSIBlockDirective(rst.Directive):

--- a/sphinxcontrib/ansi.py
+++ b/sphinxcontrib/ansi.py
@@ -34,8 +34,10 @@
 """
 
 from __future__ import absolute_import, print_function
-import re
+import logging
+import os
 from os import path
+import re
 
 from docutils import nodes
 from docutils.parsers import rst
@@ -45,6 +47,13 @@ from sphinx.util.osutil import copyfile
 
 
 __version__ = '0.7.0'
+
+# -- DIAGNOSTIC SUPPORT:
+DIAG = os.environ.get("SPHINXCONTRIB_ANSI_DIAG", "no") == "yes"
+console = logging.getLogger("sphinxcontrib.ansi")
+console.setLevel(logging.ERROR)
+if DIAG:
+    console.setLevel(logging.INFO)
 
 
 class ansi_literal_block(nodes.literal_block):
@@ -125,6 +134,8 @@ class ANSIColorParser(object):
         # this holds the end of the last regex match
         last_end = 0
         # iterate over all color codes
+        console.warn("\nANSI_COLORIZE.block:\n{}\nANSI_COLORIZE.block.end\n".format(raw))
+
         for match in COLOR_PATTERN.finditer(raw):
             # add any text preceeding this match
             head = raw[last_end:match.start()]
@@ -173,7 +184,8 @@ class ANSIColorParser(object):
 def add_stylesheet(app):
     if app.config.html_ansi_stylesheet:
         # -- RemovedInSphinx40Warning:
-        # The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
+        # The app.add_stylesheet() is deprecated. 
+        # Please use app.add_css_file() instead.
         if hasattr(app, 'add_css_file'):
             app.add_css_file('ansi.css')
         else:
@@ -225,3 +237,9 @@ def setup(app):
     app.connect('builder-inited', add_stylesheet)
     app.connect('build-finished', copy_stylesheet)
     app.connect('doctree-resolved', ANSIColorParser())
+
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/test_ansi.py
+++ b/test_ansi.py
@@ -1,30 +1,53 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# SEE: https://github.com/sphinx-doc/sphinx/
 
+from __future__ import absolute_import, print_function
 from docutils import nodes
 from mock import Mock
+from pathlib import Path
+import pytest
+import sys
 
-from sphinxcontrib import ansi
+HERE = Path(__file__).parent.resolve()
+sys.path.insert(0, str(HERE))
+
+try:
+    from sphinxcontrib import ansi
+except ImportError as e:
+    print("IMPORT-ERROR: %s" % e)
+    for index, p in enumerate(sys.path):
+        print("{0:2d}.  {1}".format(index, p))
+    raise
 
 
 RAWSOURCE = '''\
 \x1b[1mfoo\x1b[33;1mbar\x1b[1;34mhello\x1b[0mworld\x1b[1m'''
 
 
-def pytest_funcarg__paragraph(request):
+# -----------------------------------------------------------------------------
+# FIXTURES:
+# -----------------------------------------------------------------------------
+@pytest.fixture
+def paragraph():
     paragraph = nodes.paragraph()
     paragraph.append(ansi.ansi_literal_block(RAWSOURCE, RAWSOURCE))
     return paragraph
 
 
-def pytest_funcarg__app(request):
+@pytest.fixture
+def app():
     return Mock()
 
 
-def pytest_funcarg__parser(request):
+@pytest.fixture
+def parser():
     return ansi.ANSIColorParser()
 
 
+# -----------------------------------------------------------------------------
+# TEST SUPPORT:
+# -----------------------------------------------------------------------------
 def _assert_colors(node, *colors):
     assert isinstance(node, nodes.inline)
     for color in colors:
@@ -36,6 +59,10 @@ def _assert_text(node, text):
     assert node.astext() == text
 
 
+
+# -----------------------------------------------------------------------------
+# TEST SUITE:
+# -----------------------------------------------------------------------------
 def test_parser_strip_colors(app, parser, paragraph):
     app.builder.name = 'foo'
     parser(app, paragraph, 'foo')
@@ -77,10 +104,9 @@ def test_setup(app):
                       ansi.ANSIColorParser)
 
 
-def main():
-    import py
-    py.cmdline.pytest()
-
-
+# -----------------------------------------------------------------------------
+# TEST MAIN:
+# -----------------------------------------------------------------------------
 if __name__ == '__main__':
-    main()
+    import pytest
+    pytest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
+[tox]
+minversion   = 2.3
+envlist      = py39, py38, py27, doc
+skip_missing_interpreters = True
+
 [testenv]
 deps=
     -r{toxinidir}/requirements.txt
 commands=
-    py.test {posargs:--junitxml={envname}-tests.xml}
+    pytest {posargs:--junitxml={envname}-tests.xml}
 
 [testenv:doc]
-basepython=python2
+basepython=python3
 deps=
     -r{toxinidir}/doc/requirements.txt
 commands=


### PR DESCRIPTION
FIXES:

* Sphinx >= 2.0 problems (tested with Sphinx v3.3.0)
* Tests while using newer pytest versions
* Add DIAG support, enable via environment variable: `SPHINXCONTRIB_ANSI_DIAG=yes`
* Works for python2.7 and python3 (python3.8 and python3.9 tested)

OTHERWISE:
* UPDATED: CHANGES.rst
* BUMP VERSION: v0.7.0

NOT FIXED:
* LICENSE file is missing in Github repository.