### PR TITLE
Fix logging error, support dirhtml, ansi-dark

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -66,6 +66,7 @@ If you do not like the builtin stylesheets, set
 This stylesheet must provide styles for the following CSS classes:
 
 - ``ansi-bold``: Bold text
+- ``ansi-dark``: Dark text
 - ``ansi-underscore``: Underlined text
 - ``ansi-black``: Black colour
 - ``ansi-red``: Red colour

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from setuptools import setup, find_packages
 with open('README.rst') as stream:
     long_desc = stream.read()
 
-requires = ['sphinx>=1.0']
+requires = ['sphinx>=1.6']
 
 setup(
     name='sphinxcontrib-ansi',

--- a/sphinxcontrib/ansi.py
+++ b/sphinxcontrib/ansi.py
@@ -43,10 +43,13 @@ from docutils import nodes
 from docutils.parsers import rst
 from docutils.parsers.rst.directives import flag
 from sphinx.util.osutil import copyfile
+from sphinx.util.logging import getLogger
 # DISABLED: from sphinx.util.console import bold
 
 
 __version__ = '0.7.0'
+
+LOGGER = getLogger(__name__)
 
 # -- DIAGNOSTIC SUPPORT:
 DIAG = os.environ.get("SPHINXCONTRIB_ANSI_DIAG", "no") == "yes"
@@ -69,6 +72,7 @@ COLOR_PATTERN = re.compile('\x1b\\[([^m]+)m')
 #: map ANSI color codes to class names
 CODE_CLASS_MAP = {
     1: 'bold',
+    2: 'dark',
     4: 'underscore',
     30: 'black',
     31: 'red',
@@ -174,7 +178,7 @@ class ANSIColorParser(object):
         Extract and parse all ansi escapes in ansi_literal_block nodes.
         """
         handler = self._colorize_block_contents
-        if app.builder.name != 'html':
+        if app.builder.name not in ('html', 'dirhtml'):
             # strip all color codes in non-html output
             handler = self._strip_color_from_block_content
         for ansi_block in doctree.traverse(ansi_literal_block):
@@ -194,7 +198,7 @@ def add_stylesheet(app):
 
 
 def copy_stylesheet(app, exception):
-    if app.builder.name != 'html' or exception:
+    if app.builder.name not in ('html', 'dirhtml') or exception:
         return
 
     verbose = hasattr(app, 'info')
@@ -202,12 +206,12 @@ def copy_stylesheet(app, exception):
     if stylesheet:
         if verbose:
             # DISABLED; app.info(bold('Copying ansi stylesheet... '), nonl=True)
-            app.info('Copying ansi stylesheet... ', nonl=True)
+            LOGGER.info('Copying ansi stylesheet... ', nonl=True)
         dest = path.join(app.builder.outdir, '_static', 'ansi.css')
         source = path.abspath(path.dirname(__file__))
         copyfile(path.join(source, stylesheet), dest)
         if verbose:
-            app.info('done')
+            LOGGER.info('done')
 
 
 class ANSIBlockDirective(rst.Directive):

--- a/sphinxcontrib/black-on-white.css
+++ b/sphinxcontrib/black-on-white.css
@@ -7,6 +7,10 @@
     font-weight: bold;
 }
 
+.ansi-dark {
+    opacity: 0.7;
+}
+
 .ansi-black {
     color: #000000;
 }
@@ -102,4 +106,3 @@
 .ansi-bg_white {
     background-color: #b2b2b2;
 }
-


### PR DESCRIPTION
Collection of minor changes. The main one is the logging fix, since `Sphinx.info()` breaks on the latest version of Sphinx. (and has been deprecated for maybe 5 years now)